### PR TITLE
feat(api): IBフェーズStep1 口座残高・ポジションAPIを追加（疎通確認付き）

### DIFF
--- a/src/app/api/account/balance/route.ts
+++ b/src/app/api/account/balance/route.ts
@@ -1,3 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+async function pingGateway(host: string, port: number): Promise<{ ok: boolean; latencyMs?: number; error?: string }>{
+  const { default: net } = await import('net');
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const socket = new net.Socket();
+    const timeoutMs = 3000;
+    const finalize = (ok: boolean, error?: string) => {
+      try { socket.destroy(); } catch {}
+      resolve({ ok, latencyMs: Date.now() - start, error });
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finalize(true));
+    socket.once('timeout', () => finalize(false, 'timeout'));
+    socket.once('error', (err) => finalize(false, err?.message || 'error'));
+    socket.connect(port, host);
+  });
+}
+
+export async function GET(_req: NextRequest) {
+  try {
+    const host = process.env.IB_HOST || '127.0.0.1';
+    const port = Number(process.env.IB_PORT ?? 4002);
+    const accountId = process.env.IB_ACCOUNT_ID || '';
+
+    const ping = await pingGateway(host, port);
+    if (!ping.ok) {
+      return NextResponse.json({
+        success: false,
+        message: 'IB Gateway not reachable',
+        data: { host, port, accountId, error: ping.error },
+      }, { status: 503 });
+    }
+
+    // TODO: 実IB API接続に置換予定。現状はモック残高を返却
+    const mockBalance = {
+      accountId: accountId || 'UNKNOWN',
+      currency: 'JPY',
+      cashBalance: 1_000_000,
+      buyingPower: 2_500_000,
+      equityWithLoan: 1_200_000,
+      dayTradesRemaining: 3,
+      timestamp: new Date().toISOString(),
+      latencyMs: ping.latencyMs,
+      host,
+      port,
+    };
+
+    return NextResponse.json({ success: true, data: mockBalance });
+  } catch (error) {
+    console.error('Balance API error:', error);
+    return NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 });
+  }
+}
+
 import { NextResponse } from 'next/server';
 import { prisma } from '@/core/database';
 

--- a/src/app/api/positions/route.ts
+++ b/src/app/api/positions/route.ts
@@ -1,3 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+async function pingGateway(host: string, port: number): Promise<{ ok: boolean; latencyMs?: number; error?: string }>{
+  const { default: net } = await import('net');
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const socket = new net.Socket();
+    const timeoutMs = 3000;
+    const finalize = (ok: boolean, error?: string) => {
+      try { socket.destroy(); } catch {}
+      resolve({ ok, latencyMs: Date.now() - start, error });
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finalize(true));
+    socket.once('timeout', () => finalize(false, 'timeout'));
+    socket.once('error', (err) => finalize(false, err?.message || 'error'));
+    socket.connect(port, host);
+  });
+}
+
+export async function GET(_req: NextRequest) {
+  try {
+    const host = process.env.IB_HOST || '127.0.0.1';
+    const port = Number(process.env.IB_PORT ?? 4002);
+    const accountId = process.env.IB_ACCOUNT_ID || '';
+
+    const ping = await pingGateway(host, port);
+    if (!ping.ok) {
+      return NextResponse.json({
+        success: false,
+        message: 'IB Gateway not reachable',
+        data: { host, port, accountId, error: ping.error },
+      }, { status: 503 });
+    }
+
+    // TODO: 実IB API接続に置換予定。現状はモックの保有ポジションを返却
+    const mockPositions = [
+      { symbol: '7203.T', quantity: 100, avgPrice: 2500, marketPrice: 2525, pnl: 2500 },
+      { symbol: '6758.T', quantity: 50, avgPrice: 17000, marketPrice: 16890, pnl: -5500 },
+    ];
+
+    return NextResponse.json({ success: true, data: { accountId: accountId || 'UNKNOWN', positions: mockPositions, latencyMs: ping.latencyMs, host, port } });
+  } catch (error) {
+    console.error('Positions API error:', error);
+    return NextResponse.json({ success: false, message: 'Internal server error' }, { status: 500 });
+  }
+}
+
 import { NextResponse } from 'next/server';
 import { prisma } from '@/core/database';
 


### PR DESCRIPTION
- GET /api/account/balance: netソケットでIB Gateway疎通のうえモック残高を返却\n- GET /api/positions: 同様にモック保有ポジションを返却\n- Node.jsランタイム明示、将来的に実IB APIへ差し替え予定\n\nテスト方法:\n- IB Gateway起動（例: 4002）\n- curl http://localhost:3000/api/account/balance\n- curl http://localhost:3000/api/positions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Account balance and positions API endpoints now include latency measurements and gateway status information in responses.

## Bug Fixes
- Improved error handling for account balance and positions endpoints; returns detailed error information when gateway connectivity fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->